### PR TITLE
fix(actions): group events no longer misplaced under user

### DIFF
--- a/actions/events/edit.php
+++ b/actions/events/edit.php
@@ -32,7 +32,7 @@ $calendar_guid = get_input('calendar');
 $calendar = get_entity($calendar_guid);
 
 if (!$calendar instanceof Calendar) {
-	$calendar = Calendar::getPublicCalendar($user);
+	$calendar = Calendar::getPublicCalendar($container);
 }
 
 $editing = true;


### PR DESCRIPTION
Using event_ui's "+ new event" link in a group resulted in the event being
placed under the user. dayClick event adds were not broken because they
auto-injected the calendar GUID.